### PR TITLE
Add breathing animation with session timer

### DIFF
--- a/apps/meditation/src/App.tsx
+++ b/apps/meditation/src/App.tsx
@@ -1,9 +1,62 @@
+import { useState, useEffect, useRef } from "react";
+import BreathingCircle from "./components/BreathingCircle";
+import Controls from "./components/Controls";
+import DurationSelector from "./components/DurationSelector";
+import Timer from "./components/Timer";
+import { useBreathingTimer } from "./hooks/useBreathingTimer";
+import { useCompletionChime } from "./hooks/useCompletionChime";
+
 function App() {
+  const [duration, setDuration] = useState(5);
+  const timer = useBreathingTimer(duration);
+  const playChime = useCompletionChime();
+  const prevStateRef = useRef(timer.sessionState);
+
+  // Play chime when session completes
+  useEffect(() => {
+    if (prevStateRef.current !== "complete" && timer.sessionState === "complete") {
+      playChime();
+    }
+    prevStateRef.current = timer.sessionState;
+  }, [timer.sessionState, playChime]);
+
+  const isActive = timer.sessionState === "running" || timer.sessionState === "paused";
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-900">
-      <h1 className="text-6xl font-light tracking-widest text-slate-300">
-        breathe
-      </h1>
+    <div className="flex min-h-screen select-none flex-col items-center justify-center gap-10 bg-slate-900 px-4">
+      {/* Duration selector - hidden during active session */}
+      <div className={`transition-opacity duration-500 ${isActive ? "pointer-events-none opacity-0" : "opacity-100"}`}>
+        <DurationSelector
+          selected={duration}
+          onChange={setDuration}
+          disabled={isActive}
+        />
+      </div>
+
+      {/* Breathing circle */}
+      <BreathingCircle
+        phase={timer.phase}
+        phaseProgress={timer.phaseProgress}
+        isActive={timer.sessionState === "running"}
+      />
+
+      {/* Timer display */}
+      <Timer elapsedMs={timer.elapsedMs} totalMs={timer.totalMs} />
+
+      {/* Session complete message */}
+      {timer.sessionState === "complete" && (
+        <p className="animate-pulse text-sm tracking-widest text-sky-300/70">
+          session complete
+        </p>
+      )}
+
+      {/* Controls */}
+      <Controls
+        sessionState={timer.sessionState}
+        onStart={timer.start}
+        onPause={timer.pause}
+        onReset={timer.reset}
+      />
     </div>
   );
 }

--- a/apps/meditation/src/components/BreathingCircle.tsx
+++ b/apps/meditation/src/components/BreathingCircle.tsx
@@ -1,0 +1,68 @@
+import type { BreathPhase } from "../hooks/useBreathingTimer";
+
+interface Props {
+  phase: BreathPhase;
+  phaseProgress: number;
+  isActive: boolean;
+}
+
+const PHASE_LABELS: Record<BreathPhase, string> = {
+  inhale: "breathe in",
+  hold: "hold",
+  exhale: "breathe out",
+};
+
+function getCircleScale(phase: BreathPhase, progress: number): number {
+  switch (phase) {
+    case "inhale":
+      return 0.6 + 0.4 * progress;
+    case "hold":
+      return 1;
+    case "exhale":
+      return 1 - 0.4 * progress;
+  }
+}
+
+function getCircleOpacity(phase: BreathPhase, progress: number): number {
+  switch (phase) {
+    case "inhale":
+      return 0.3 + 0.4 * progress;
+    case "hold":
+      return 0.7;
+    case "exhale":
+      return 0.7 - 0.4 * progress;
+  }
+}
+
+export default function BreathingCircle({ phase, phaseProgress, isActive }: Props) {
+  const scale = isActive ? getCircleScale(phase, phaseProgress) : 0.6;
+  const opacity = isActive ? getCircleOpacity(phase, phaseProgress) : 0.3;
+
+  return (
+    <div className="relative flex h-72 w-72 items-center justify-center sm:h-80 sm:w-80">
+      {/* Outer glow ring */}
+      <div
+        className="absolute inset-0 rounded-full bg-sky-500/20 blur-xl transition-transform duration-100"
+        style={{ transform: `scale(${scale * 1.1})` }}
+      />
+      {/* Main breathing circle */}
+      <div
+        className="absolute inset-4 rounded-full border border-sky-400/30 transition-transform duration-100"
+        style={{
+          transform: `scale(${scale})`,
+          backgroundColor: `rgba(56, 189, 248, ${opacity * 0.15})`,
+          boxShadow: `0 0 ${40 * opacity}px rgba(56, 189, 248, ${opacity * 0.3})`,
+        }}
+      />
+      {/* Inner circle */}
+      <div
+        className="absolute inset-16 rounded-full border border-sky-300/20 transition-transform duration-100"
+        style={{ transform: `scale(${scale})` }}
+      />
+      {/* Phase label */}
+      <span className="relative z-10 text-xl font-light tracking-widest text-slate-300 sm:text-2xl">
+        {isActive ? PHASE_LABELS[phase] : "breathe"}
+      </span>
+    </div>
+  );
+}

--- a/apps/meditation/src/components/Controls.tsx
+++ b/apps/meditation/src/components/Controls.tsx
@@ -1,0 +1,38 @@
+import type { SessionState } from "../hooks/useBreathingTimer";
+
+interface Props {
+  sessionState: SessionState;
+  onStart: () => void;
+  onPause: () => void;
+  onReset: () => void;
+}
+
+export default function Controls({ sessionState, onStart, onPause, onReset }: Props) {
+  return (
+    <div className="flex gap-4">
+      {sessionState === "running" ? (
+        <button
+          onClick={onPause}
+          className="rounded-full bg-slate-700/50 px-8 py-3 text-sm font-medium tracking-wide text-slate-300 transition-colors hover:bg-slate-700"
+        >
+          pause
+        </button>
+      ) : (
+        <button
+          onClick={onStart}
+          className="rounded-full bg-sky-500/20 px-8 py-3 text-sm font-medium tracking-wide text-sky-300 ring-1 ring-sky-400/30 transition-colors hover:bg-sky-500/30"
+        >
+          {sessionState === "idle" ? "start" : sessionState === "complete" ? "restart" : "resume"}
+        </button>
+      )}
+      {sessionState !== "idle" && (
+        <button
+          onClick={onReset}
+          className="rounded-full bg-slate-800/50 px-8 py-3 text-sm font-medium tracking-wide text-slate-500 transition-colors hover:text-slate-300"
+        >
+          reset
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/meditation/src/components/DurationSelector.tsx
+++ b/apps/meditation/src/components/DurationSelector.tsx
@@ -1,0 +1,28 @@
+const DURATIONS = [5, 10, 15];
+
+interface Props {
+  selected: number;
+  onChange: (minutes: number) => void;
+  disabled: boolean;
+}
+
+export default function DurationSelector({ selected, onChange, disabled }: Props) {
+  return (
+    <div className="flex gap-3">
+      {DURATIONS.map((min) => (
+        <button
+          key={min}
+          onClick={() => onChange(min)}
+          disabled={disabled}
+          className={`rounded-full px-5 py-2 text-sm font-medium transition-all ${
+            selected === min
+              ? "bg-sky-500/20 text-sky-300 ring-1 ring-sky-400/40"
+              : "text-slate-500 hover:text-slate-300"
+          } disabled:cursor-not-allowed disabled:opacity-40`}
+        >
+          {min}m
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/meditation/src/components/Timer.tsx
+++ b/apps/meditation/src/components/Timer.tsx
@@ -1,0 +1,31 @@
+interface Props {
+  elapsedMs: number;
+  totalMs: number;
+}
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export default function Timer({ elapsedMs, totalMs }: Props) {
+  const remainingMs = Math.max(0, totalMs - elapsedMs);
+  const progress = totalMs > 0 ? elapsedMs / totalMs : 0;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <span className="font-mono text-2xl font-light tracking-wider text-slate-400">
+        {formatTime(remainingMs)}
+      </span>
+      {/* Progress bar */}
+      <div className="h-0.5 w-32 overflow-hidden rounded-full bg-slate-800">
+        <div
+          className="h-full rounded-full bg-sky-500/40 transition-all duration-300"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/meditation/src/hooks/useBreathingTimer.ts
+++ b/apps/meditation/src/hooks/useBreathingTimer.ts
@@ -1,0 +1,113 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export type BreathPhase = "inhale" | "hold" | "exhale";
+export type SessionState = "idle" | "running" | "paused" | "complete";
+
+const PHASE_DURATION = 4000; // 4 seconds per phase
+const PHASES: BreathPhase[] = ["inhale", "hold", "exhale"];
+
+export function useBreathingTimer(durationMinutes: number) {
+  const [sessionState, setSessionState] = useState<SessionState>("idle");
+  const [phase, setPhase] = useState<BreathPhase>("inhale");
+  const [phaseProgress, setPhaseProgress] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  const animFrameRef = useRef<number>(0);
+  const phaseStartRef = useRef(0);
+  const phaseIndexRef = useRef(0);
+  const sessionStartRef = useRef(0);
+  const pausedElapsedRef = useRef(0);
+  const pausedPhaseElapsedRef = useRef(0);
+
+  const totalMs = durationMinutes * 60 * 1000;
+
+  const tick = useCallback(
+    (now: number) => {
+      const sessionElapsed = pausedElapsedRef.current + (now - sessionStartRef.current);
+      const phaseElapsed = pausedPhaseElapsedRef.current + (now - phaseStartRef.current);
+
+      if (sessionElapsed >= totalMs) {
+        setSessionState("complete");
+        setElapsedMs(totalMs);
+        setPhaseProgress(0);
+        return;
+      }
+
+      setElapsedMs(sessionElapsed);
+
+      if (phaseElapsed >= PHASE_DURATION) {
+        phaseIndexRef.current = (phaseIndexRef.current + 1) % PHASES.length;
+        setPhase(PHASES[phaseIndexRef.current]);
+        phaseStartRef.current = now;
+        pausedPhaseElapsedRef.current = 0;
+        setPhaseProgress(0);
+      } else {
+        setPhaseProgress(phaseElapsed / PHASE_DURATION);
+      }
+
+      animFrameRef.current = requestAnimationFrame(tick);
+    },
+    [totalMs],
+  );
+
+  const start = useCallback(() => {
+    const now = performance.now();
+    if (sessionState === "idle" || sessionState === "complete") {
+      phaseIndexRef.current = 0;
+      setPhase("inhale");
+      setPhaseProgress(0);
+      setElapsedMs(0);
+      pausedElapsedRef.current = 0;
+      pausedPhaseElapsedRef.current = 0;
+      sessionStartRef.current = now;
+      phaseStartRef.current = now;
+    } else if (sessionState === "paused") {
+      sessionStartRef.current = now;
+      phaseStartRef.current = now;
+    }
+    setSessionState("running");
+    animFrameRef.current = requestAnimationFrame(tick);
+  }, [sessionState, tick]);
+
+  const pause = useCallback(() => {
+    if (sessionState !== "running") return;
+    cancelAnimationFrame(animFrameRef.current);
+    const now = performance.now();
+    pausedElapsedRef.current += now - sessionStartRef.current;
+    pausedPhaseElapsedRef.current += now - phaseStartRef.current;
+    setSessionState("paused");
+  }, [sessionState]);
+
+  const reset = useCallback(() => {
+    cancelAnimationFrame(animFrameRef.current);
+    setSessionState("idle");
+    setPhase("inhale");
+    setPhaseProgress(0);
+    setElapsedMs(0);
+    phaseIndexRef.current = 0;
+    pausedElapsedRef.current = 0;
+    pausedPhaseElapsedRef.current = 0;
+  }, []);
+
+  useEffect(() => {
+    return () => cancelAnimationFrame(animFrameRef.current);
+  }, []);
+
+  // Reset when duration changes while idle
+  useEffect(() => {
+    if (sessionState === "idle") {
+      setElapsedMs(0);
+    }
+  }, [durationMinutes, sessionState]);
+
+  return {
+    sessionState,
+    phase,
+    phaseProgress,
+    elapsedMs,
+    totalMs,
+    start,
+    pause,
+    reset,
+  };
+}

--- a/apps/meditation/src/hooks/useCompletionChime.ts
+++ b/apps/meditation/src/hooks/useCompletionChime.ts
@@ -1,0 +1,32 @@
+import { useRef, useCallback } from "react";
+
+export function useCompletionChime() {
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const play = useCallback(() => {
+    const ctx = audioCtxRef.current ?? new AudioContext();
+    audioCtxRef.current = ctx;
+
+    // Play a gentle two-tone chime
+    const playTone = (freq: number, startTime: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(freq, startTime);
+      gain.gain.setValueAtTime(0, startTime);
+      gain.gain.linearRampToValueAtTime(0.3, startTime + 0.05);
+      gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+
+    const now = ctx.currentTime;
+    playTone(528, now, 1.5);
+    playTone(660, now + 0.3, 1.5);
+    playTone(792, now + 0.6, 2);
+  }, []);
+
+  return play;
+}


### PR DESCRIPTION
## Summary
- Circular breathing animation (inhale 4s, hold 4s, exhale 4s) with smooth scaling and glow effects
- Session duration selector (5, 10, 15 min) with countdown timer and progress bar
- Start/pause/reset controls and audio chime on session completion
- Dark-themed, mobile-optimized minimal UI

Closes #2

## Test plan
- [ ] Verify breathing circle animates through inhale/hold/exhale phases at 4s intervals
- [ ] Test duration selector switches between 5/10/15 minute sessions
- [ ] Confirm start/pause/resume/reset controls work correctly
- [ ] Verify countdown timer displays remaining time accurately
- [ ] Check audio chime plays on session completion
- [ ] Test on mobile viewport for responsive layout
- [ ] Verify build passes

https://claude.ai/code/session_01UV2j9PgCtFgB24Jp4edJS8