### PR TITLE
Add session tracking, streaks, and stats view (issue #6)

### DIFF
--- a/apps/meditation/src/App.tsx
+++ b/apps/meditation/src/App.tsx
@@ -3,30 +3,47 @@ import BreathingCircle from "./components/BreathingCircle";
 import Controls from "./components/Controls";
 import DurationSelector from "./components/DurationSelector";
 import PatternSelector from "./components/PatternSelector";
+import StatsView from "./components/StatsView";
 import Timer from "./components/Timer";
 import { useBreathingTimer } from "./hooks/useBreathingTimer";
 import { useCompletionChime } from "./hooks/useCompletionChime";
+import { useSessionStorage } from "./hooks/useSessionStorage";
 import { PATTERNS } from "./patterns";
 
 function App() {
   const [duration, setDuration] = useState(5);
   const [pattern, setPattern] = useState(PATTERNS[0]);
+  const [showStats, setShowStats] = useState(false);
   const timer = useBreathingTimer(duration, pattern);
   const playChime = useCompletionChime();
+  const { sessions, recordSession, stats } = useSessionStorage();
   const prevStateRef = useRef(timer.sessionState);
 
-  // Play chime when session completes
+  // Play chime and record session when session completes
   useEffect(() => {
     if (prevStateRef.current !== "complete" && timer.sessionState === "complete") {
       playChime();
+      recordSession(duration, pattern.id);
     }
     prevStateRef.current = timer.sessionState;
-  }, [timer.sessionState, playChime]);
+  }, [timer.sessionState, playChime, recordSession, duration, pattern.id]);
 
   const isActive = timer.sessionState === "running" || timer.sessionState === "paused";
 
+  if (showStats) {
+    return <StatsView sessions={sessions} stats={stats} onClose={() => setShowStats(false)} />;
+  }
+
   return (
     <div className="flex min-h-screen select-none flex-col items-center justify-center gap-8 bg-slate-900 px-4">
+      {/* Stats button */}
+      <button
+        onClick={() => setShowStats(true)}
+        className={`absolute top-4 right-4 text-xs tracking-widest text-slate-500 uppercase transition-opacity hover:text-slate-300 ${isActive ? "opacity-0 pointer-events-none" : "opacity-100"}`}
+      >
+        Stats
+      </button>
+
       {/* Pattern and duration selectors - hidden during active session */}
       <div className={`flex flex-col items-center gap-6 transition-opacity duration-500 ${isActive ? "pointer-events-none opacity-0" : "opacity-100"}`}>
         <PatternSelector

--- a/apps/meditation/src/components/StatsView.tsx
+++ b/apps/meditation/src/components/StatsView.tsx
@@ -1,0 +1,111 @@
+import type { MeditationSession } from "../hooks/useSessionStorage";
+
+interface Props {
+  sessions: MeditationSession[];
+  stats: {
+    totalSessions: number;
+    totalMinutes: number;
+    currentStreak: number;
+    longestStreak: number;
+    days: Set<string>;
+  };
+  onClose: () => void;
+}
+
+function toDateStr(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function ActivityCalendar({ days }: { days: Set<string> }) {
+  const cells: { dateStr: string; active: boolean }[] = [];
+  const today = new Date();
+
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const dateStr = toDateStr(d);
+    cells.push({ dateStr, active: days.has(dateStr) });
+  }
+
+  return (
+    <div className="w-full">
+      <p className="mb-2 text-xs tracking-widest text-slate-500 uppercase">Last 30 days</p>
+      <div className="grid grid-cols-10 gap-1">
+        {cells.map(({ dateStr, active }) => (
+          <div
+            key={dateStr}
+            title={dateStr}
+            className={`aspect-square rounded-sm ${
+              active ? "bg-sky-400" : "bg-slate-700"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function StatsView({ sessions, stats, onClose }: Props) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-start bg-slate-900 px-6 pt-12 pb-8">
+      {/* Header */}
+      <div className="mb-8 flex w-full max-w-sm items-center justify-between">
+        <h1 className="text-lg font-semibold tracking-widest text-slate-200 uppercase">Stats</h1>
+        <button
+          onClick={onClose}
+          className="text-sm tracking-widest text-slate-400 uppercase transition-colors hover:text-slate-200"
+        >
+          ← Back
+        </button>
+      </div>
+
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        {/* Streak cards */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col items-center rounded-xl bg-slate-800 py-5 px-4">
+            <span className="mb-1 text-2xl">🔥</span>
+            <span className="text-3xl font-bold text-slate-100">{stats.currentStreak}</span>
+            <span className="mt-1 text-center text-xs tracking-widest text-slate-400 uppercase">
+              Current streak
+            </span>
+          </div>
+          <div className="flex flex-col items-center rounded-xl bg-slate-800 py-5 px-4">
+            <span className="mb-1 text-2xl">🏆</span>
+            <span className="text-3xl font-bold text-slate-100">{stats.longestStreak}</span>
+            <span className="mt-1 text-center text-xs tracking-widest text-slate-400 uppercase">
+              Longest streak
+            </span>
+          </div>
+        </div>
+
+        {/* Total stats */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col items-center rounded-xl bg-slate-800 py-5 px-4">
+            <span className="text-3xl font-bold text-slate-100">{stats.totalSessions}</span>
+            <span className="mt-1 text-center text-xs tracking-widest text-slate-400 uppercase">
+              Sessions
+            </span>
+          </div>
+          <div className="flex flex-col items-center rounded-xl bg-slate-800 py-5 px-4">
+            <span className="text-3xl font-bold text-slate-100">{stats.totalMinutes}</span>
+            <span className="mt-1 text-center text-xs tracking-widest text-slate-400 uppercase">
+              Minutes
+            </span>
+          </div>
+        </div>
+
+        {/* Activity calendar */}
+        <div className="rounded-xl bg-slate-800 p-4">
+          <ActivityCalendar days={stats.days} />
+        </div>
+
+        {/* Empty state */}
+        {sessions.length === 0 && (
+          <p className="text-center text-sm tracking-widest text-slate-500">
+            Complete your first session to start tracking progress.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/meditation/src/hooks/useSessionStorage.ts
+++ b/apps/meditation/src/hooks/useSessionStorage.ts
@@ -1,0 +1,95 @@
+import { useState, useCallback } from "react";
+
+export interface MeditationSession {
+  date: string; // YYYY-MM-DD
+  duration: number; // minutes
+  patternId: string;
+  completedAt: string; // ISO timestamp
+}
+
+const STORAGE_KEY = "meditation_sessions";
+
+function toDateStr(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function loadSessions(): MeditationSession[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as MeditationSession[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function computeStats(sessions: MeditationSession[]) {
+  const totalSessions = sessions.length;
+  const totalMinutes = sessions.reduce((sum, s) => sum + s.duration, 0);
+
+  // Build a set of unique days with sessions
+  const days = new Set(sessions.map((s) => s.date));
+
+  // Compute current streak (consecutive days ending today or yesterday)
+  let currentStreak = 0;
+  const today = toDateStr(new Date());
+  let cursor = new Date();
+
+  // Start from today; if no session today, start from yesterday
+  if (!days.has(today)) {
+    cursor.setDate(cursor.getDate() - 1);
+  }
+
+  while (days.has(toDateStr(cursor))) {
+    currentStreak++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+
+  // Compute longest streak
+  if (days.size === 0) {
+    return { totalSessions, totalMinutes, currentStreak: 0, longestStreak: 0, days };
+  }
+
+  const sortedDays = Array.from(days).sort();
+  let longest = 1;
+  let run = 1;
+  for (let i = 1; i < sortedDays.length; i++) {
+    const prev = new Date(sortedDays[i - 1]);
+    const curr = new Date(sortedDays[i]);
+    const diff = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
+    if (diff === 1) {
+      run++;
+      longest = Math.max(longest, run);
+    } else {
+      run = 1;
+    }
+  }
+
+  return { totalSessions, totalMinutes, currentStreak, longestStreak: longest, days };
+}
+
+export function useSessionStorage() {
+  const [sessions, setSessions] = useState<MeditationSession[]>(loadSessions);
+
+  const recordSession = useCallback((duration: number, patternId: string) => {
+    const now = new Date();
+    const session: MeditationSession = {
+      date: toDateStr(now),
+      duration,
+      patternId,
+      completedAt: now.toISOString(),
+    };
+    setSessions((prev) => {
+      const updated = [...prev, session];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      } catch {
+        // ignore storage errors
+      }
+      return updated;
+    });
+  }, []);
+
+  const stats = computeStats(sessions);
+
+  return { sessions, recordSession, stats };
+}


### PR DESCRIPTION
- Record completed sessions to localStorage with date, duration, and pattern
- Calculate current and longest streaks from session history
- Add StatsView with streak cards, totals, and 30-day activity calendar
- Add Stats button on main screen to navigate to stats view

https://claude.ai/code/session_01Eik2gunUwe1TTVxnYgxwyr