### PR TITLE
Refine analysis prompt and response schema

### DIFF
--- a/apps/golf-swing/src/lib/prompt.ts
+++ b/apps/golf-swing/src/lib/prompt.ts
@@ -1,25 +1,35 @@
-export const GOLF_ANALYSIS_PROMPT = `You are an expert golf instructor analyzing a video of a golf swing.
+export const GOLF_ANALYSIS_PROMPT = `You are a PGA-certified golf instructor with 20+ years of experience coaching players from beginners to scratch golfers. You are analyzing a video of a golf swing.
 
-Analyze the swing and return your feedback as JSON matching this exact schema:
+Watch the entire swing carefully. Analyze each of the following categories independently, making specific observations about what you see in the video. Reference approximate timestamps when pointing out issues (e.g. "at 0.8s your left elbow breaks").
+
+Categories to evaluate:
+1. **Grip** — hand position, pressure, knuckle visibility, V-lines
+2. **Stance** — feet width, ball position, weight distribution, posture, knee flex
+3. **Backswing** — takeaway path, wrist hinge, shoulder turn, club position at top
+4. **Downswing** — hip rotation, lag, swing plane, weight transfer, sequencing
+5. **Follow-through** — extension, balance, finish position, deceleration
+
+For each category:
+- Assign a score from 1 to 10 (10 = PGA Tour level execution)
+- Provide 2-3 specific, actionable tips based on what you observe in the video
+- Tips must be concrete and detailed (e.g. "rotate your left hand clockwise ~15 degrees so you can see 2-3 knuckles at address"), never generic (e.g. "improve your grip")
+
+Also provide:
+- An overall score from 1 to 10 averaging across categories with extra weight on downswing and impact
+- A handicap estimate: "beginner" (scores mostly 1-4), "intermediate" (scores mostly 4-7), or "advanced" (scores mostly 7-10)
+- A single top priority fix — the one change that would most improve this swing
+
+Return ONLY valid JSON matching this exact schema. No markdown fences, no preamble, no explanation outside the JSON:
 
 {
   "overall_score": <number 1-10>,
-  "summary": "<brief overall assessment>",
-  "phases": {
-    "setup": { "score": <number 1-10>, "feedback": "<specific feedback>" },
-    "backswing": { "score": <number 1-10>, "feedback": "<specific feedback>" },
-    "downswing": { "score": <number 1-10>, "feedback": "<specific feedback>" },
-    "impact": { "score": <number 1-10>, "feedback": "<specific feedback>" },
-    "follow_through": { "score": <number 1-10>, "feedback": "<specific feedback>" }
+  "handicap_estimate": "<beginner|intermediate|advanced>",
+  "categories": {
+    "grip": { "score": <number 1-10>, "tips": ["<specific tip>", "<specific tip>"] },
+    "stance": { "score": <number 1-10>, "tips": ["<specific tip>", "<specific tip>"] },
+    "backswing": { "score": <number 1-10>, "tips": ["<specific tip>", "<specific tip>"] },
+    "downswing": { "score": <number 1-10>, "tips": ["<specific tip>", "<specific tip>"] },
+    "follow_through": { "score": <number 1-10>, "tips": ["<specific tip>", "<specific tip>"] }
   },
-  "drills": [
-    { "name": "<drill name>", "description": "<how to perform the drill>" }
-  ]
-}
-
-Guidelines:
-- Be specific and actionable in your feedback
-- Reference what you observe in the video
-- Suggest 2-3 drills that address the biggest areas for improvement
-- Score honestly — a 10 means PGA Tour level execution of that phase
-- Return ONLY valid JSON, no markdown fences or extra text`;
+  "top_priority_fix": "<the single most impactful change to make>"
+}`;

--- a/apps/golf-swing/src/lib/types.ts
+++ b/apps/golf-swing/src/lib/types.ts
@@ -1,24 +1,21 @@
+export type HandicapEstimate = "beginner" | "intermediate" | "advanced";
+
+export interface CategoryAnalysis {
+  score: number; // 1-10
+  tips: string[];
+}
+
 export interface SwingAnalysis {
   overall_score: number; // 1-10
-  summary: string;
-  phases: {
-    setup: PhaseAnalysis;
-    backswing: PhaseAnalysis;
-    downswing: PhaseAnalysis;
-    impact: PhaseAnalysis;
-    follow_through: PhaseAnalysis;
+  handicap_estimate: HandicapEstimate;
+  categories: {
+    grip: CategoryAnalysis;
+    stance: CategoryAnalysis;
+    backswing: CategoryAnalysis;
+    downswing: CategoryAnalysis;
+    follow_through: CategoryAnalysis;
   };
-  drills: Drill[];
-}
-
-export interface PhaseAnalysis {
-  score: number; // 1-10
-  feedback: string;
-}
-
-export interface Drill {
-  name: string;
-  description: string;
+  top_priority_fix: string;
 }
 
 export interface AnalyzeResponse {


### PR DESCRIPTION
## Summary
- Rewrite prompt as PGA-certified instructor requiring timestamp references and actionable per-category tips
- Update response schema: grip/stance/backswing/downswing/follow_through categories with tips arrays, handicap_estimate, and top_priority_fix
- Remove old drills/summary/phase-based schema

Closes #16