### PR TITLE
Add SwingFeedback results display and wire into upload page (issue #17)

### DIFF
--- a/apps/golf-swing/src/app/page.tsx
+++ b/apps/golf-swing/src/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
+import type { SwingAnalysis } from "@/lib/types";
+import SwingFeedback from "@/components/SwingFeedback";
 
 const ACCEPTED_TYPES = ["video/mp4", "video/quicktime", "video/webm"];
 const MAX_DURATION_S = 30;
@@ -16,6 +18,7 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null);
   const [isValid, setIsValid] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [analysis, setAnalysis] = useState<SwingAnalysis | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -25,6 +28,7 @@ export default function HomePage() {
     setPreviewUrl(null);
     setError(null);
     setIsValid(false);
+    setAnalysis(null);
   }, [previewUrl]);
 
   const handleFileChange = useCallback(
@@ -75,9 +79,30 @@ export default function HomePage() {
   const handleSubmit = async () => {
     if (!file || !isValid) return;
     setIsSubmitting(true);
-    // TODO: API integration
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    setIsSubmitting(false);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("video", file);
+
+      const res = await fetch("/api/analyze", {
+        method: "POST",
+        body: formData,
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error ?? "Analysis failed. Please try again.");
+        return;
+      }
+
+      setAnalysis(data.analysis);
+    } catch {
+      setError("Network error. Please check your connection and try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -163,14 +188,19 @@ export default function HomePage() {
         )}
 
         {/* Submit button */}
-        <button
-          type="button"
-          disabled={!isValid || isSubmitting}
-          onClick={handleSubmit}
-          className="w-full rounded-lg bg-green-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500"
-        >
-          {isSubmitting ? "Uploading…" : "Analyze Swing"}
-        </button>
+        {!analysis && (
+          <button
+            type="button"
+            disabled={!isValid || isSubmitting}
+            onClick={handleSubmit}
+            className="w-full rounded-lg bg-green-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500"
+          >
+            {isSubmitting ? "Analyzing…" : "Analyze Swing"}
+          </button>
+        )}
+
+        {/* Results */}
+        {analysis && <SwingFeedback analysis={analysis} />}
       </div>
     </main>
   );

--- a/apps/golf-swing/src/components/SwingFeedback.tsx
+++ b/apps/golf-swing/src/components/SwingFeedback.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import type { SwingAnalysis, CategoryAnalysis } from "@/lib/types";
+
+function scoreColor(score: number): string {
+  if (score <= 3) return "text-red-600";
+  if (score <= 6) return "text-yellow-600";
+  return "text-green-600";
+}
+
+function barColor(score: number): string {
+  if (score <= 3) return "bg-red-500";
+  if (score <= 6) return "bg-yellow-500";
+  return "bg-green-500";
+}
+
+function badgeStyle(estimate: string): string {
+  switch (estimate) {
+    case "beginner":
+      return "bg-blue-100 text-blue-800";
+    case "intermediate":
+      return "bg-yellow-100 text-yellow-800";
+    case "advanced":
+      return "bg-green-100 text-green-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  grip: "Grip",
+  stance: "Stance",
+  backswing: "Backswing",
+  downswing: "Downswing",
+  follow_through: "Follow-through",
+};
+
+function CategoryRow({
+  name,
+  category,
+}: {
+  name: string;
+  category: CategoryAnalysis;
+}) {
+  const [open, setOpen] = useState(false);
+  const label = CATEGORY_LABELS[name] ?? name;
+
+  return (
+    <div className="border-b border-gray-100 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-3 py-3 text-left"
+      >
+        <span className="w-28 shrink-0 text-sm font-medium text-gray-700">
+          {label}
+        </span>
+        <div className="flex-1">
+          <div className="h-2.5 w-full rounded-full bg-gray-200">
+            <div
+              className={`h-2.5 rounded-full ${barColor(category.score)}`}
+              style={{ width: `${category.score * 10}%` }}
+            />
+          </div>
+        </div>
+        <span
+          className={`w-8 text-right text-sm font-bold ${scoreColor(category.score)}`}
+        >
+          {category.score}
+        </span>
+        <svg
+          className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m19.5 8.25-7.5 7.5-7.5-7.5"
+          />
+        </svg>
+      </button>
+      {open && (
+        <ul className="pb-3 pl-4 space-y-1.5">
+          {category.tips.map((tip, i) => (
+            <li key={i} className="flex gap-2 text-sm text-gray-600">
+              <span className="shrink-0 text-gray-400">&bull;</span>
+              <span>{tip}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function SwingFeedback({
+  analysis,
+}: {
+  analysis: SwingAnalysis;
+}) {
+  return (
+    <div className="space-y-5">
+      {/* Top priority fix */}
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">
+          Top Priority
+        </p>
+        <p className="mt-1 text-sm text-amber-900">
+          {analysis.top_priority_fix}
+        </p>
+      </div>
+
+      {/* Overall score + handicap */}
+      <div className="flex items-center gap-4">
+        <div className="flex flex-col items-center">
+          <span
+            className={`text-5xl font-extrabold ${scoreColor(analysis.overall_score)}`}
+          >
+            {analysis.overall_score}
+          </span>
+          <span className="mt-0.5 text-xs text-gray-500">/ 10</span>
+        </div>
+        <div>
+          <span
+            className={`inline-block rounded-full px-3 py-1 text-xs font-semibold capitalize ${badgeStyle(analysis.handicap_estimate)}`}
+          >
+            {analysis.handicap_estimate}
+          </span>
+        </div>
+      </div>
+
+      {/* Category scores */}
+      <div className="rounded-lg border border-gray-200 bg-white px-4">
+        {Object.entries(analysis.categories).map(([name, category]) => (
+          <CategoryRow key={name} name={name} category={category} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Color-coded overall score, handicap badge, per-category progress bars
with expandable tips, and highlighted top-priority-fix callout. Page now
calls /api/analyze on submit and renders results below the video preview.

https://claude.ai/code/session_01NwCXEigYGKL1G6DnUEDLKZ